### PR TITLE
EventGetter improvements

### DIFF
--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -129,15 +129,12 @@ class AbstractEventGenerator(object):
         if self.event_counter >= self.max_events:
             raise StopIteration
 
-        try:
-            event_header = self.read_header()
-            data = self.read_adc_data()
+        event_header = self.read_header()
+        data = self.read_adc_data()
 
-            self.event_counter += 1
-            return Event(event_header, self.roi, data)
+        self.event_counter += 1
+        return Event(event_header, self.roi, data)
 
-        except struct.error:
-            raise StopIteration
 
     def read_adc_data(self):
         ''' return array of raw ADC data, shape:(16, roi)


### PR DESCRIPTION
* fix bug in __repr__
* use max_events to stop iteration before broken event.

unfortunately need to use an internal counter. `EventGetter.event_counter` and cannot refer to `event.header.event_counter` anymore, since the new `header.event_counter` of the next possibly broken event is not available yet. And the last `header.event_counter` is not available to the EventGetter anymore.

This results in an ugly 
~~~
self.event_counter -= 2
~~~
in `self.previous()`

