### PR TITLE
Event Getter provide time

### DIFF
--- a/dragonboard/__init__.py
+++ b/dragonboard/__init__.py
@@ -1,4 +1,4 @@
-from .io import read, EventGenerator, Event
+from .io import read, EventGenerator
 from .plotting import DragonBrowser
 from .runningstats import RunningStats
 

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -28,9 +28,6 @@ stop_cell_map = {
 
 max_roi = 4096
 gaintypes = ["low", "high"]
-stop_cell_dtype = np.dtype('uint16').newbyteorder('>')
-stop_cell_size = 8 * stop_cell_dtype.itemsize
-expected_relative_address_of_flag = 16
 num_channels = 8
 num_gains = 2
 adc_word_size = 2

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -84,14 +84,14 @@ class AbstractEventGenerator(object):
         num_events = filesize / self.event_size
         if not num_events.is_integer():
             warnings.warn(("\n"
-                "File:\n"
-                "{0}\n"
-                "might be broken.\n"
-                "Number of events "
-                "is not integer but {1:.2f}.").format(
-                    self.path,
-                    num_events
-                ))
+                           "File:\n"
+                           "{0}\n"
+                           "might be broken.\n"
+                           "Number of events "
+                           "is not integer but {1:.2f}.").format(
+                self.path,
+                num_events
+            ))
         return int(num_events)
 
     def __len__(self):
@@ -133,7 +133,6 @@ class AbstractEventGenerator(object):
 
         self.event_counter += 1
         return self.Event(event_header, self.roi, data)
-
 
     def read_adc_data(self):
         ''' return array of raw ADC data, shape:(16, roi)
@@ -212,7 +211,7 @@ class EventGenerator_v5_1_05(AbstractEventGenerator):
 
     def calc_roi(self):
         body_size = self.event_size - self.header_size
-        roi = body_size/(adc_word_size * num_gains * num_channels)
+        roi = body_size / (adc_word_size * num_gains * num_channels)
         assert roi.is_integer()
         return int(roi)
 
@@ -321,7 +320,7 @@ class EventGenerator_v5_1_0B(AbstractEventGenerator):
 
         chunk = self.read_chunk()
 
-        data_header = b'\xdd'*8
+        data_header = b'\xdd' * 8
         first_data_header = chunk.find(data_header)
         second_data_header = chunk.find(data_header, first_data_header + 1)
 
@@ -352,4 +351,5 @@ def guess_version(path):
             return version_name
         except:
             pass
-    raise IOError('File version could not be determined for file {}'.format(path))
+    raise IOError(
+        'File version could not be determined for file {}'.format(path))

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -257,6 +257,7 @@ class EventGenerator_v5_1_0B(AbstractEventGenerator):
         'counter_133MHz',
         'counter_10MHz',
         'pps_counter',
+        'timestamp',
         'stop_cells',
         'flag',
     ])
@@ -298,12 +299,15 @@ class EventGenerator_v5_1_0B(AbstractEventGenerator):
             chip = stop_cell_map[(g, p)]
             stop_cells_for_user[g][p] = stop_cells__in_drs4_chip_order[chip]
 
+        timestamp = counter_133MHz / 133e6
+
         return self.EventHeader(
             event_counter,
             trigger_counter,
             counter_133MHz,
             counter_10MHz,
             pps_counter,
+            timestamp,
             stop_cells_for_user,
             flags
         )

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -39,7 +39,8 @@ def read(path, max_events=None):
 
 
 class AbstractEventGenerator(object):
-    Event = namedtuple('Event', ['header', 'roi', 'data', 'time_since_last_readout'])
+    Event = namedtuple(
+        'Event', ['header', 'roi', 'data', 'time_since_last_readout'])
     header_size = None
 
     def __init__(self, path, max_events=None):
@@ -157,8 +158,10 @@ class AbstractEventGenerator(object):
         for g, p in stop_cell_map:
             sc = event_header.stop_cells[g][p]
 
-            time_since_last_readout[g][p] = np.roll(self.last_seen[g][p], -sc)[:self.roi]
-            time_since_last_readout[g][p] = event_header.timestamp - time_since_last_readout[g][p]
+            time_since_last_readout[g][p] = np.roll(
+                self.last_seen[g][p], -sc)[:self.roi]
+            time_since_last_readout[g][
+                p] = event_header.timestamp - time_since_last_readout[g][p]
 
             cells = (np.arange(self.roi) + sc) % max_roi
             self.last_seen[g][p][cells] = event_header.timestamp

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -31,7 +31,6 @@ gaintypes = ["low", "high"]
 stop_cell_dtype = np.dtype('uint16').newbyteorder('>')
 stop_cell_size = 8 * stop_cell_dtype.itemsize
 expected_relative_address_of_flag = 16
-timestamp_conversion_to_s = 7.5e-9
 num_channels = 8
 num_gains = 2
 adc_word_size = 2
@@ -164,6 +163,7 @@ class AbstractEventGenerator(object):
 
 class EventGenerator_v5_1_05(AbstractEventGenerator):
     header_size = 3 * 16
+    timestamp_conversion_to_s = 7.5e-9
 
     EventHeader = namedtuple('EventHeader', [
         'event_counter',
@@ -203,7 +203,7 @@ class EventGenerator_v5_1_05(AbstractEventGenerator):
             chip = stop_cell_map[(g, p)]
             stop_cells_for_user[g][p] = stop_cells__in_drs4_chip_order[chip]
 
-        timestamp_in_s = clock * timestamp_conversion_to_s
+        timestamp_in_s = clock * self.timestamp_conversion_to_s
 
         return self.EventHeader(
             event_id, trigger_id, timestamp_in_s, stop_cells_for_user, found_flag

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -26,8 +26,6 @@ stop_cell_map = {
     ("low", 7): 7,
 }
 
-Event = namedtuple('Event', ['header', 'roi', 'data'])
-
 max_roi = 4096
 gaintypes = ["low", "high"]
 stop_cell_dtype = np.dtype('uint16').newbyteorder('>')
@@ -45,6 +43,7 @@ def read(path, max_events=None):
 
 
 class AbstractEventGenerator(object):
+    Event = namedtuple('Event', ['header', 'roi', 'data'])
     header_size = None
 
     def __init__(self, path, max_events=None):
@@ -133,7 +132,7 @@ class AbstractEventGenerator(object):
         data = self.read_adc_data()
 
         self.event_counter += 1
-        return Event(event_header, self.roi, data)
+        return self.Event(event_header, self.roi, data)
 
 
     def read_adc_data(self):

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -66,6 +66,7 @@ class AbstractEventGenerator(object):
                 ("high", 'f4', max_roi),
             ]
         )
+        self._alarm_previous_was_called = False
 
     def __repr__(self):
         return(
@@ -141,6 +142,7 @@ class AbstractEventGenerator(object):
         try:
             self.file_descriptor.seek(- 2 * self.event_size, 1)
             self.event_counter -= 2
+            self._alarm_previous_was_called = True
         except OSError:
             raise ValueError('Already at first event')
         return self.next()
@@ -154,6 +156,8 @@ class AbstractEventGenerator(object):
                 ("high", 'f4', self.roi),
             ]
         )
+        if self._alarm_previous_was_called:
+            return time_since_last_readout
 
         for g, p in stop_cell_map:
             sc = event_header.stop_cells[g][p]


### PR DESCRIPTION
Based on the last results accomplished by Mario and Max, I understand, we learned that the offsets depend *at least* on:

 * cell_id,
 * (relative) sample_id,
 * delta_t: time since a cell_id was last read out

We might not yet have the dependency of these parameters fully understood, but I strongly believe we should be prepared to let users of the `EventGetter` have easy access to these parameters.