### PR TITLE
Save timelapse data

### DIFF
--- a/scripts/fit_delta_t.py
+++ b/scripts/fit_delta_t.py
@@ -25,12 +25,18 @@ def f(x, a, b, c):
 def fit(df, cell, plot=False):
     df = df[(5 <= df['sample']) & (df['sample'] < 35)]
 
+    p0 = [
+        1.3,
+        -0.38,
+        df.adc_counts[df.delta_t > 0.05].mean(),
+    ]
+
     try:
         (a, b, c), cov = curve_fit(
             f,
             df['delta_t'],
             df['adc_counts'],
-            p0=[2,  -0.3, 230],
+            p0=p0,
         )
     except RuntimeError:
         logging.error('Could not fit cell {}'.format(cell))

--- a/scripts/fit_delta_t.py
+++ b/scripts/fit_delta_t.py
@@ -1,0 +1,85 @@
+'''
+Usage:
+    fit_delta_t.py <inputfile> <pixel> <gain> [options]
+
+Options:
+    -p, --plot              Show plots while fitting
+    -n <n>, --n-jobs=<n>    How many threads to use [default: 1]
+'''
+import pandas as pd
+from scipy.optimize import curve_fit
+from joblib import Parallel, delayed
+import numpy as np
+import matplotlib.pyplot as plt
+import logging
+from docopt import docopt
+
+fig = None
+x = np.logspace(-4, 0, 250)
+
+
+def f(x, a, b, c):
+    return a * x ** b + c
+
+
+def fit(df, cell, plot=False):
+    df = df[(5 <= df['sample']) & (df['sample'] < 35)]
+
+    try:
+        (a, b, c), cov = curve_fit(
+            f,
+            df['delta_t'],
+            df['adc_counts'],
+            p0=[2,  -0.3, 230],
+        )
+    except RuntimeError:
+        logging.error('Could not fit cell {}'.format(cell))
+        return np.full(4, np.nan)
+
+    if plot:
+        global fig, ax, x
+
+        if fig is None:
+            fig = plt.figure()
+            ax = fig.add_subplot(1, 1, 1)
+            fig.tight_layout()
+
+        ax.cla()
+        ax.set_xscale('log')
+        ax.set_xlim(1e-4, 1)
+        ax.scatter(
+            x='delta_t', y='adc_counts', c='sample',
+            cmap='rainbow', linewidth=0, s=4,
+            data=df,
+        )
+        ax.plot(x, f(x, a, b, c))
+
+        fig.canvas.draw()
+        plt.pause(1e-9)
+
+    ndf = len(df.index) - 3
+    residuals = df['adc_counts'] - f(df['delta_t'], a, b, c)
+    chisquare = np.sum(residuals**2) / ndf
+
+    return a, b, c, chisquare
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+
+    plt.rcParams['figure.figsize'] = (4, 3)
+    plt.ion()
+
+    pixel = args['<pixel>']
+    gain = args['<gain>']
+
+    data = pd.read_hdf(args['<inputfile>'], 'pixel_{}_{}'.format(pixel, gain))
+    by_cell = data.groupby('cell')
+
+    with Parallel(int(args['--n-jobs']), verbose=5) as pool:
+        result = pd.DataFrame(
+            pool(delayed(fit)(df, name, plot=args['--plot']) for name, df in by_cell),
+            columns=['a', 'b', 'c', 'chisq_ndf']
+        )
+
+    result.to_hdf('fit_results_{}_{}.hdf5'.format(pixel, gain), 'fit_result')

--- a/scripts/timelapse_dataextraction.py
+++ b/scripts/timelapse_dataextraction.py
@@ -1,13 +1,6 @@
 '''
-#######################################################
-*          Dragon board readout software              *
-* calculate time-lapse dependence from pedestal files *
-#######################################################
-
-annotations:
-
-- inputdirectory is the path to the directory of your pedestal files
-
+Save (cell, sample, time_since_last_readout, adc_counts) to an hdf5 file
+for all given inputfiles.
 
 Usage:
   offset_calculation.py <inputfiles> ... [options]

--- a/scripts/timelapse_dataextraction.py
+++ b/scripts/timelapse_dataextraction.py
@@ -37,10 +37,6 @@ def write(store, data):
         )
 
 
-def kill():
-    os.system('kill {}'.format(os.getpid()))
-
-
 def extract_data(inputfiles):
     ''' calculate time lapse dependence for a given capacitor '''
 
@@ -65,7 +61,7 @@ def extract_data(inputfiles):
 
                         stop_cell = event.header.stop_cells[pixel][gain]
 
-                        delta_ts = event.since[pixel][gain]
+                        delta_ts = event.time_since_last_readout[pixel][gain]
                         valid = np.logical_not(np.isnan(delta_ts))
                         if not np.any(valid):
                             continue

--- a/scripts/timelapse_dataextraction.py
+++ b/scripts/timelapse_dataextraction.py
@@ -1,0 +1,99 @@
+'''
+#######################################################
+*          Dragon board readout software              *
+* calculate time-lapse dependence from pedestal files *
+#######################################################
+
+annotations:
+
+- inputdirectory is the path to the directory of your pedestal files
+
+
+Usage:
+  offset_calculation.py <inputfiles> ... [options]
+  offset_calculation.py (-h | --help)
+  offset_calculation.py --version
+
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  --outpath N   Outputfile path [default: calibration_constants.pickle]
+
+'''
+
+import dragonboard as dr
+from tqdm import tqdm
+import os
+from docopt import docopt
+import pandas as pd
+from collections import defaultdict
+import numpy as np
+
+
+def write(store, data):
+    for (pixel, gain), value in data.items():
+        df = pd.DataFrame(value)
+        df['sample'] = df['sample'].astype('int16')
+        df['adc_counts'] = df['adc_counts'].astype('int16')
+        df['cell'] = df['cell'].astype('int16')
+        df['delta_t'] = df['delta_t'].astype('float32')
+
+        store.append(
+            'pixel_{}_{}'.format(pixel, gain),
+            df,
+        )
+
+
+def kill():
+    os.system('kill {}'.format(os.getpid()))
+
+
+def extract_data(inputfiles):
+    ''' calculate time lapse dependence for a given capacitor '''
+
+    with pd.HDFStore('data.hdf5', mode='w', comp_level=5, comp_lib='blosc') as store:
+
+        sample_ids = None
+        for filename in sorted(inputfiles):
+            data = defaultdict(lambda: defaultdict(list))
+
+            for event in tqdm(
+                    iterable=dr.EventGenerator(filename),
+                    desc=os.path.basename(filename),
+                    leave=True,
+                    unit=' events',
+                    ):
+
+                if sample_ids is None or sample_ids.shape != event.roi:
+                    sample_ids = np.arange(event.roi)
+
+                for pixel, pixel_data in enumerate(event.data):
+                    for gain in pixel_data.dtype.names:
+
+                        stop_cell = event.header.stop_cells[pixel][gain]
+
+                        delta_ts = event.since[pixel][gain]
+                        valid = np.logical_not(np.isnan(delta_ts))
+                        if not np.any(valid):
+                            continue
+
+                        data[(pixel, gain)]['delta_t'].extend(delta_ts[valid])
+                        data[(pixel, gain)]['cell'].extend(
+                            dr.sample2cell(sample_ids[valid], stop_cell)
+                        )
+                        data[(pixel, gain)]['sample'].extend(sample_ids[valid])
+                        data[(pixel, gain)]['adc_counts'].extend(pixel_data[gain][valid])
+
+                if (event.header.event_counter + 1) % 10000 == 0:
+
+                    write(store, data)
+                    data = defaultdict(lambda: defaultdict(list))
+
+            write(store, data)
+
+
+if __name__ == '__main__':
+    arguments = docopt(
+        __doc__, version='Dragon Board Time-Dependent Offset Calculation v.1.0'
+    )
+    extract_data(arguments['<inputfiles>'])


### PR DESCRIPTION
This provides 2 new scripts:

* `extract_timelapse_data` that extracts `(cell, sample, delta_t, adc_counts)` for all events and all pixels and all gains in the given files and saves it to a `hdf5` file.

* `fit_timelapse_data` that can perform mario's fit in parallel and saves the fit constants and the chisquare to an `hdf5` file. It can also plot the fits on the fly. This is a lot slower.