### PR TITLE
calc_timelapse_constants

### DIFF
--- a/dragonboard/__init__.py
+++ b/dragonboard/__init__.py
@@ -3,6 +3,8 @@ from .plotting import DragonBrowser
 from .runningstats import RunningStats
 from .utils import cell2sample, sample2cell, cell_in_samples
 
+import pkg_resources
+__version__ = pkg_resources.require('dragonboard')[0].version
 
 __all__ = [
     'read',

--- a/dragonboard/plotting.py
+++ b/dragonboard/plotting.py
@@ -94,7 +94,7 @@ class DragonBrowser(QtGui.QMainWindow):
         for channel in range(self.n_channels):
             for gain in self.gains:
                 plot, = self.axs[gain].plot(
-                    [], [], '_', ms=10, mew=1, label='Ch{}'.format(channel)
+                    [], [], '.:', ms=10, mew=1, label='Ch{}'.format(channel)
                 )
                 plot.set_visible(False)
                 self.plots[gain][channel] = plot

--- a/dragonboard/tools/calc_timelapse_constants.py
+++ b/dragonboard/tools/calc_timelapse_constants.py
@@ -38,6 +38,13 @@ def f(x, a, b, c):
 
 
 def fit(adc, delta_t, cell):
+    a0 = 1.3
+    b0 = -0.38
+    c0 = 0
+
+    if not len(adc):
+        return a0, b0, c0, np.nan
+
     big_time = np.percentile(delta_t, 75)
     p0 = [
         1.3,
@@ -51,9 +58,9 @@ def fit(adc, delta_t, cell):
             adc,
             p0=p0,
         )
-    except RuntimeError:
+    except (RuntimeError, TypeError):
         logging.error('Could not fit cell {}'.format(cell))
-        return np.full(4, np.nan)
+        return p0[0], p0[1], p0[2], np.nan
 
     ndf = len(adc) - 3
     residuals = adc - f(delta_t, a, b, c)
@@ -107,10 +114,10 @@ def main():
                 data = event.data[pixel][gain][skip_slice]
                 delta_ts = event.time_since_last_readout[pixel][gain][skip_slice]
                 for i, cid in enumerate(cell_ids):
-                    delta_t[pixel, gain][cid].append(delta_ts[i])            
+                    delta_t[pixel, gain][cid].append(delta_ts[i])
                     adc[pixel, gain][cid].append(data[i])
 
-    for key in sorted(adc.keys():
+    for key in sorted(adc.keys()):
         # adc and delta_t have the same keys
         for i in tqdm(range(4096), desc=str(key)):
             adc[key][i] = np.array(adc[key][i], dtype=adc[key][i].typecode)

--- a/dragonboard/tools/calc_timelapse_constants.py
+++ b/dragonboard/tools/calc_timelapse_constants.py
@@ -4,8 +4,8 @@ Usage:
 
 Options:
   --max_events N    integer; maximum events to be used from a file. default is all.
-  --skip_begin N    integer; number of start-samples to be skipped for fitting [default: 9]
-  --skip_end N      integer; number of end-samples to be skipped for fitting [default: 2]
+  --skip_begin N    integer; number of start-samples to be skipped for fitting [default: 5]
+  --skip_end N      integer; number of end-samples to be skipped for fitting [default: 5]
   --do_channel8     fit also channel 8 values
 '''
 

--- a/dragonboard/tools/calc_timelapse_constants.py
+++ b/dragonboard/tools/calc_timelapse_constants.py
@@ -1,0 +1,167 @@
+'''
+Usage:
+  calc_timelapse_constants <outputfile> <inputfiles> ... [options]
+
+Options:
+  --max_events N    integer; maximum events to be used from a file. default is all.
+  --skip_begin N    integer; number of start-samples to be skipped for fitting [default: 9]
+  --skip_end N      integer; number of end-samples to be skipped for fitting [default: 2]
+  --do_channel8     fit also channel 8 values
+'''
+
+import os
+import sys
+import psutil
+import logging
+from tqdm import tqdm
+from docopt import docopt
+
+from joblib import Parallel, delayed
+
+import numpy as np
+
+import pandas as pd
+
+import scipy.sparse
+from scipy.sparse import lil_matrix, coo_matrix
+from scipy.optimize import curve_fit
+
+import dragonboard as dr
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def f(x, a, b, c):
+    return a * x ** b + c
+
+
+def fit(adc, delta_t, cell):
+    big_time = np.percentile(delta_t, 75)
+    p0 = [
+        1.3,
+        -0.38,
+        adc[delta_t >= big_time].mean(),
+    ]
+    try:
+        (a, b, c), cov = curve_fit(
+            f,
+            delta_t,
+            adc,
+            p0=p0,
+        )
+    except RuntimeError:
+        logging.error('Could not fit cell {}'.format(cell))
+        return np.full(4, np.nan)
+
+    ndf = len(adc) - 3
+    residuals = adc - f(delta_t, a, b, c)
+    chisquare = np.sum(residuals**2) / ndf
+
+    return a, b, c, chisquare
+
+def main():
+    args = docopt(__doc__)
+    args["--max_events"] = None if args["--max_events"] is None else int(args["--max_events"])
+    args["--skip_begin"] = int(args["--skip_begin"])
+    args["--skip_end"] = int(args["--skip_end"])
+    args["--do_channel8"] = bool(args["--do_channel8"])
+    store = pd.HDFStore(args['<outputfile>'], 'w')
+
+
+    print("reading raw file(s) into memory:")
+    egs = [dr.EventGenerator(filename, max_events=args["--max_events"]) for filename in args["<inputfiles>"]]
+
+    adc = {}
+    delta_t = {}
+    for pixel in range(8 if args["--do_channel8"] else 7):
+        for gain in ["high", "low"]:
+            adc[pixel, gain] = [[] for i in range(4096)]
+            delta_t[pixel, gain] = [[] for i in range(4096)]
+    
+    for eg in egs:
+        sample_ids = np.arange(eg.roi)
+
+        for event in tqdm(
+                iterable=eg,
+                desc=os.path.basename(eg.path),
+                leave=True,
+                unit=' events',
+                ):
+
+            for pixel, gain in sorted(adc.keys()):
+
+                sc = event.header.stop_cells[pixel][gain]
+                cell_ids = dr.sample2cell(sample_ids, sc)
+                
+                skip_slice = slice(args["--skip_begin"], -args["--skip_end"])
+                cell_ids = cell_ids[skip_slice]
+                data = event.data[pixel][gain][skip_slice]
+                delta_ts = event.time_since_last_readout[pixel][gain][skip_slice]
+                for i, cid in enumerate(cell_ids):
+                    delta_t[pixel, gain][cid].append(delta_ts[i])            
+                    adc[pixel, gain][cid].append(data[i])
+    """
+    for key in adc:
+        for i in range(len(adc[key])):
+            print(key, i, len(adc[key][i]))
+    """
+    print("converting lists to numpy arrays:")
+    for key in tqdm(iterable=sorted(adc.keys()),
+                    leave=True):
+        # adc and delta_t have the same keys
+        for i in tqdm(range(4096), desc=str(key)):
+            adc[key][i] = np.array(adc[key][i], dtype=np.int16)
+            delta_t[key][i] = np.array(delta_t[key][i], dtype=np.float32)
+
+            adc[key][i] = adc[key][i][~np.isnan(delta_t[key][i])]
+            delta_t[key][i] = delta_t[key][i][~np.isnan(delta_t[key][i])]
+
+
+
+    print("fitting")
+    pool = Parallel(max(psutil.cpu_count()-1, 1))
+    for key in tqdm(iterable=sorted(adc.keys()),
+                    leave=True):
+        result = pd.DataFrame(
+            pool(delayed(fit)(adc[key][i], delta_t[key][i], i) for i in range(4096)),
+            columns=['a', 'b', 'c', 'chisq_ndf']
+        )
+        pixel, channel = key
+        result['pixel'] = pixel
+        result['channel'] = channel
+        result['cell'] = np.arange(4096)
+
+        store.append('data', result, min_itemsize={'channel': 4})
+
+    if not args["--do_channel8"]:
+        # We need to put nans for channel 8 into the output file, since the 
+        # rest of the system expects this data to be there ... even if it its nan.
+
+        result = pd.DataFrame( np.full((4096, 4), np.nan),
+            columns=['a', 'b', 'c', 'chisq_ndf']
+        )
+        pixel = 7
+        channel = "high"
+        result['pixel'] = pixel
+        result['channel'] = channel
+        result['cell'] = np.arange(4096)
+
+        store.append('data', result, min_itemsize={'channel': 4})
+
+
+        result = pd.DataFrame( np.full((4096, 4), np.nan),
+            columns=['a', 'b', 'c', 'chisq_ndf']
+        )
+        pixel = 7
+        channel = "low"
+        result['pixel'] = pixel
+        result['channel'] = channel
+        result['cell'] = np.arange(4096)
+
+
+        store.append('data', result, min_itemsize={'channel': 4})
+
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='dragonboard',
-    version='0.0.4',
+    version='0.0.5',
     description='A reader library for the cta dragonboard data',
     url='http://github.com/cta-observatory/dragonboard_testbench',
     author='Kai Brügge, Mario Hörbe, Dominik Neise, Maximilian Nöthe',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
             'dragonboard_fakedata = dragonboard.tools.create_fake_data:main',
             'dragonboard_calc_calib_constants = dragonboard.tools.calc_calib_constants:main',
             'dragonboard_dataextraction = dragonboard.tools.dataextraction:main',
+            'calc_timelapse_constants = dragonboard.tools.calc_timelapse_constants:main',
         ]
     }
 )


### PR DESCRIPTION
I combined the two scripts,  which are currently needed to create a DRS4 calibration file, which can be used by the `TimelapseCalibration`. working title is "calc_timelapse_constants"

So instead of calling:
`dragonboard_dataextraction /path_to_rawdata/some_files_*.dat --outpath data.h5 --memory 60`
and then:
`dragonboard_calc_calib_constants data.h5 calib.h5 -n 7`

one can call:
`calc_timelapse_constants calib.h5 /path_to_rawdata/some_files_*.dat`

By default it uses all CPUs minus one (or one if only one is there).
It uses all the memory it can get and this might be a lot...
It is a little bit faster than the other two.
It does not even try to extract calibration constants for the 8th channel.