### PR TITLE
Include custom tiny analysis steps into dragonviewer

### DIFF
--- a/dragonboard/example_analysis.py
+++ b/dragonboard/example_analysis.py
@@ -1,0 +1,43 @@
+"""
+Example: 
+dragon browser analysis fun:
+
+"""
+import numpy as np
+
+def print_mean_std(channel, gain, data, stop_cell, axis):
+    print("{name}: {mean:0.1f} {std:0.1f}".format(
+        name=channel,
+        mean=data.mean(),
+        std=data.std(),
+        )
+    )
+
+def digital_leading_edge_discriminator(data, time, threshold=0, window_length=0):
+    z = np.where(np.diff(np.signbit(data-threshold)))[0][0]
+    s = slice(z-window_length, z+2+window_length)
+    m, b = np.polyfit(time[s], data[s], deg=1)
+    return (threshold-b)/m
+
+def find_leading_edge_1500(channel, gain, data, stop_cell, axis):
+    arrival_time = digital_leading_edge_discriminator(
+        data=data,
+        time=np.arange(len(data)),
+        threshold=1500,
+    )
+    axis.axvline(arrival_time, color='k')
+
+from scipy import interpolate
+
+def integrate_around_arrival_time_2(channel, gain, data, stop_cell, axis):
+    arrival_time = digital_leading_edge_discriminator(
+        data=data,
+        time=np.arange(len(data)),
+        threshold=1500,
+    )
+    interpolant = interpolate.interp1d(np.arange(len(data)), data, kind='cubic')
+    start = arrival_time - 2
+    end = arrival_time + 2
+
+    fill_x = np.linspace(start, end, 20)
+    axis.fill_between(fill_x, interpolant(fill_x))

--- a/dragonboard/io.py
+++ b/dragonboard/io.py
@@ -46,7 +46,7 @@ class AbstractEventGenerator(object):
     header_size = None
     Event = Event
 
-    def __init__(self, path, max_events=None):
+    def __init__(self, path, max_events=None, start=None):
         self.path = os.path.realpath(path)
 
         self.file_descriptor = open(self.path, "rb")
@@ -70,6 +70,10 @@ class AbstractEventGenerator(object):
             ]
         )
         self._alarm_previous_was_called = False
+
+        start = start if start is not None else 0
+        for i in range(start):
+            next(self)
 
     def __repr__(self):
         return(
@@ -389,11 +393,11 @@ version_map = {
 }
 
 
-def EventGenerator(path, max_events=None, version=None):
+def EventGenerator(path, version=None, **kwargs):
     if version is None:
-        return version_map[guess_version(path)](path, max_events)
+        return version_map[guess_version(path)](path, **kwargs)
     else:
-        return version_map[version](path, max_events)
+        return version_map[version](path, **kwargs)
 
 
 def guess_version(path):


### PR DESCRIPTION
I spent an entire day on this (and learned a little PyQt4 in the process) 
... not sure if it is really of any use ... but in the morning I liked the idea :-D

The story goes like this:

In fact-tools we have the nice event viewer, which can produce a lot of plots and stuff, based on what has been added to the event. While looking at events, and especially at the sampled time series, I often want to plot, print, or somehow highlight a certain quantity, like:
 * show the mean over the time line, maybe as a horizontal dashed line? 
 * show me, where the arrival time would be ... I cannot see that by eye.
 * print something ... maybe even a statistic about the events, I've seen so far.

----

Now adding features in Python is easy. But PyQT4 I personally find difficult to use, and merging Qt4 and matplotlib, can feel even more difficult for people. So I though it would be nice to be able to hook simple functions, into the dragon viewer, which get the event, and print or plot something we like.

One might use the `dragonviewer` like this normally:
```{r, engine='bash', count_lines}
    cd to/my/data/folder
    dragonviewer some_data_file.dat
```
Now assume, one looked at some events and suddenly wanted to calculate something on a certain time line and print it out. One knows how to code it ... maybe somehow like this .... 
```python
def my_funny_func(channel, gain, data, stop_cell):
    print("awesome result of channel {channel}: {result}".format(
        channel=channel,
        result=data.mean() + 3*data.std() - stop_cell)
    )
```
... but one doesn't know how to include this into the viewer ... and it seems too cumbersome to create a complete app for this. 

-----

Now all the user needs to do, is this:
```python
# dragon_analysis.py
def my_funny_func(channel, gain, data, stop_cell, axis):
    print("awesome result of channel {channel}: {result}".format(
        channel=channel,
        result=data.mean() + 3*data.std() - stop_cell)
    )
```
So implement the function one has in mind in a file called `dragon_analysis.py` in the **current folder**. And start the dragon viewer again.

The viewer has now, on its upper right side, a text box, with the names of all functions, which have the correct signature, i.e. the accept parameters with the names `{'axis', 'stop_cell', 'data', 'gain', 'channel'}`

On the lower right side, the stdout of the functions, the user has implement gets shown.

![2016-07-01-170936_1920x1080_scrot](https://cloud.githubusercontent.com/assets/8200858/16525926/00fc64cc-3faf-11e6-86a4-27f3c798a2d6.png)

Via the `axis` parameter, one can even manipulate the plot. In case there is no `dragon_analysis.py` in the python path, an `example_analysis.py` from the dragonboard module is imported. This is how this looks at the moment.

![2016-07-01-172205_1920x1080_scrot](https://cloud.githubusercontent.com/assets/8200858/16526222/70f28102-3fb0-11e6-8257-05ccf3ce22b9.png)
